### PR TITLE
Replace disabled stderr redirection char ^ with 2>

### DIFF
--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,6 +1,6 @@
 # fzf-autojump initialization hook
 
 bind \eH '__fzf_autojump'
-if bind -M insert >/dev/null ^/dev/null
+if bind -M insert >/dev/null 2>/dev/null
   bind -M insert \eH '__fzf_autojump'
 end


### PR DESCRIPTION
Since [Fish 3.3.0][1], redirection to standard error with the `^` character has been disabled by default.

Reference: [oh-my-fish/oh-my-fish#585][2]

p.s.: this is the result of an automated process. Apologies if there is already another pull request that addresses this issue.

[1]: https://github.com/fish-shell/fish-shell/blob/master/CHANGELOG.rst#deprecations-and-removed-features-1
[2]: https://github.com/oh-my-fish/oh-my-fish/issues/585
